### PR TITLE
Make `value::Value` and `value::Type` newtypes.

### DIFF
--- a/src/parser.rs
+++ b/src/parser.rs
@@ -768,12 +768,12 @@ mod tests {
         let ty = Type::option(Type::BOOL);
         assert_eq!(
             parse_value("true", &ty),
-            Value::make_option(&ty, Some(Value::Bool(true))).unwrap()
+            Value::make_option(&ty, Some(Value::make_bool(true))).unwrap()
         );
         let ty = Type::result(Some(Type::BOOL), None);
         assert_eq!(
             parse_value("false", &ty),
-            Value::make_result(&ty, Ok(Some(Value::Bool(false)))).unwrap()
+            Value::make_result(&ty, Ok(Some(Value::make_bool(false)))).unwrap()
         );
     }
 

--- a/src/ty.rs
+++ b/src/ty.rs
@@ -127,7 +127,7 @@ pub trait WasmType: Clone + Sized {
 }
 
 macro_rules! maybe_unwrap {
-    ($ty:ident, $case:path) => {
+    ($ty:expr, $case:path) => {
         match $ty {
             $case(v) => Some(v),
             _ => None,

--- a/src/val.rs
+++ b/src/val.rs
@@ -288,7 +288,7 @@ pub trait WasmValue: Clone + Sized {
 }
 
 macro_rules! unwrap_val {
-    ($val:ident, $case:path, $name:expr) => {
+    ($val:expr, $case:path, $name:expr) => {
         match $val {
             $case(v) => v,
             _ => panic!("called unwrap_{name} on non-{name} value", name = $name),

--- a/src/value/convert.rs
+++ b/src/value/convert.rs
@@ -1,4 +1,4 @@
-use crate::{ty::WasmTypeKind, WasmType, WasmValue};
+use crate::{ty::WasmTypeKind, value::ValueEnum, WasmType, WasmValue};
 
 use super::{Type, Value};
 
@@ -56,7 +56,7 @@ macro_rules! impl_primitives {
 
             impl From<$ty> for $Self {
                 fn from(value: $ty) -> Self {
-                    Self::$case(value)
+                    Self(ValueEnum::$case(value))
                 }
             }
         )*
@@ -87,7 +87,7 @@ impl ValueTyped for String {
 
 impl From<String> for Value {
     fn from(value: String) -> Self {
-        Self::String(value.into())
+        Self(ValueEnum::String(value.into()))
     }
 }
 

--- a/src/value/tests.rs
+++ b/src/value/tests.rs
@@ -5,17 +5,17 @@ use super::{Type, Value};
 #[test]
 fn simple_value_round_trips() {
     for val in [
-        Value::Bool(true),
-        Value::U8(u8::MAX),
-        Value::U16(u16::MAX),
-        Value::U32(u32::MAX),
-        Value::U64(u64::MAX),
-        Value::S8(i8::MIN),
-        Value::S16(i16::MIN),
-        Value::S32(i32::MIN),
-        Value::S64(i64::MIN),
-        Value::Char('☃'),
-        Value::String("str".into()),
+        Value::make_bool(true),
+        Value::make_u8(u8::MAX),
+        Value::make_u16(u16::MAX),
+        Value::make_u32(u32::MAX),
+        Value::make_u64(u64::MAX),
+        Value::make_s8(i8::MIN),
+        Value::make_s16(i16::MIN),
+        Value::make_s32(i32::MIN),
+        Value::make_s64(i64::MIN),
+        Value::make_char('☃'),
+        Value::make_string("str".into()),
     ] {
         test_value_round_trip(val)
     }
@@ -32,8 +32,8 @@ fn float_round_trips() {
         (f32::INFINITY, f64::INFINITY),
         (f32::NEG_INFINITY, f64::NEG_INFINITY),
     ] {
-        test_value_round_trip(Value::Float32(float32));
-        test_value_round_trip(Value::Float64(float64));
+        test_value_round_trip(Value::make_float32(float32));
+        test_value_round_trip(Value::make_float64(float64));
     }
 }
 
@@ -41,8 +41,8 @@ fn float_round_trips() {
 fn list_round_trips() {
     let ty = Type::list(Type::U8);
     test_value_round_trip(Value::make_list(&ty, []).unwrap());
-    test_value_round_trip(Value::make_list(&ty, [Value::U8(1)]).unwrap());
-    test_value_round_trip(Value::make_list(&ty, [Value::U8(1), Value::U8(2)]).unwrap());
+    test_value_round_trip(Value::make_list(&ty, [Value::make_u8(1)]).unwrap());
+    test_value_round_trip(Value::make_list(&ty, [Value::make_u8(1), Value::make_u8(2)]).unwrap());
 }
 
 #[test]
@@ -53,7 +53,7 @@ fn record_round_trip() {
     let record_val = Value::make_record(
         &record_ty,
         [
-            ("field-a", Value::Bool(true)),
+            ("field-a", Value::make_bool(true)),
             ("field-b", Value::make_option(&option_ty, None).unwrap()),
         ],
     )
@@ -64,7 +64,7 @@ fn record_round_trip() {
 #[test]
 fn tuple_round_trip() {
     let ty = Type::tuple([Type::BOOL, Type::U8]).unwrap();
-    let val = Value::make_tuple(&ty, [Value::Bool(true), Value::U8(1)]).unwrap();
+    let val = Value::make_tuple(&ty, [Value::make_bool(true), Value::make_u8(1)]).unwrap();
     test_value_round_trip(val);
 }
 
@@ -72,7 +72,7 @@ fn tuple_round_trip() {
 fn variant_round_trips() {
     let ty = Type::variant([("off", None), ("on", Some(Type::U8))]).unwrap();
     test_value_round_trip(Value::make_variant(&ty, "off", None).unwrap());
-    test_value_round_trip(Value::make_variant(&ty, "on", Some(Value::U8(1))).unwrap());
+    test_value_round_trip(Value::make_variant(&ty, "on", Some(Value::make_u8(1))).unwrap());
 }
 
 #[test]
@@ -85,7 +85,7 @@ fn enum_round_trips() {
 #[test]
 fn option_round_trips() {
     let ty = Type::option(Type::U8);
-    test_value_round_trip(Value::make_option(&ty, Some(Value::U8(1))).unwrap());
+    test_value_round_trip(Value::make_option(&ty, Some(Value::make_u8(1))).unwrap());
     test_value_round_trip(Value::make_option(&ty, None).unwrap());
 }
 
@@ -98,12 +98,12 @@ fn result_round_trips() {
     for (ty, payload) in [
         (&no_payloads, Ok(None)),
         (&no_payloads, Err(None)),
-        (&both_payloads, Ok(Some(Value::U8(1)))),
-        (&both_payloads, Err(Some(Value::String("oops".into())))),
-        (&ok_only, Ok(Some(Value::U8(1)))),
+        (&both_payloads, Ok(Some(Value::make_u8(1)))),
+        (&both_payloads, Err(Some(Value::make_string("oops".into())))),
+        (&ok_only, Ok(Some(Value::make_u8(1)))),
         (&ok_only, Err(None)),
         (&err_only, Ok(None)),
-        (&err_only, Err(Some(Value::String("oops".into())))),
+        (&err_only, Err(Some(Value::make_string("oops".into())))),
     ] {
         let val = Value::make_result(ty, payload).unwrap();
         test_value_round_trip(val);


### PR DESCRIPTION
Change `value::Value` and `value::Type` from `pub` enums with arms that use private types, to a public newtype, making the actual `enum` private.

This makes the API easier to understand, as it fully hides types like `SimpleType` which are private.

https://docs.rs/wasm-wave/latest/wasm_wave/value/enum.Value.html https://docs.rs/wasm-wave/latest/wasm_wave/value/enum.Type.html