### PR TITLE
Allow '%'-prefixed identifiers, following Wit.

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Whitespace is _insignificant between tokens_ and _significant within tokens_: ke
 
 ### Labels
 
-Kebab-case labels are used for record fields, variant cases, enum cases, and flags. Labels use ASCII alphanumeric characters and hyphens, following the [Component Model `label` syntax](https://github.com/WebAssembly/component-model/blob/main/design/mvp/Explainer.md).
+Kebab-case labels are used for record fields, variant cases, enum cases, and flags. Labels use ASCII alphanumeric characters and hyphens, following the [Wit identifier syntax](https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#identifiers).
 
 ### Bools
 

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -99,6 +99,12 @@ impl<'a> Tokenizer<'a> {
                 self.eat_while(|ch| ch.is_ascii_alphanumeric() || ch == '-');
                 Token::Name
             }
+            '%' => {
+                // A `%`-prefixed identifier.
+                self.pos += 1;
+                self.eat_while(|ch| ch.is_ascii_alphanumeric() || ch == '-');
+                Token::Name
+            }
             '0'..='9' => {
                 // Eat characters from numbers (including decimals and exponents)
                 self.eat_while(|ch| matches!(ch, '0'..='9' | '-' | '.' | 'e' | 'E' | '+'));

--- a/wave_ebnf.md
+++ b/wave_ebnf.md
@@ -62,7 +62,7 @@ record-fields ::= ws record-field ws
                 | record-fields ',' record-field
 record-field ::= label ws ':' ws value
 
-label ::= word
+label ::= '%'? word
        | label '-' word
 word ::= [a-z][a-z0-9]*
        | [A-Z][A-Z0-9]*

--- a/wave_ebnf.md
+++ b/wave_ebnf.md
@@ -62,8 +62,9 @@ record-fields ::= ws record-field ws
                 | record-fields ',' record-field
 record-field ::= label ws ':' ws value
 
-label ::= '%'? word
-       | label '-' word
+label ::= '%'? inner-label
+inner-label ::= word
+              | inner-label '-' word
 word ::= [a-z][a-z0-9]*
        | [A-Z][A-Z0-9]*
 ```


### PR DESCRIPTION
[Wit identifiers] can be prefixed with '%' in order to avoid colliding with reserved names in Wit. Wave itself doesn't have all of Wit's reserved names, but it is still useful to recognize '%'-prefixed names in cases where Wave values are embedded in Wit-superset languages which do have reserved names.

Consequently, switch the reference for identifiers from the Component Model `label` syntax to the Wit identifier syntax.

[Wit identifiers]: https://github.com/WebAssembly/component-model/blob/main/design/mvp/WIT.md#identifiers