### PR TITLE
Fix `Value::make_flags` to sort the flags.

### DIFF
--- a/src/val.rs
+++ b/src/val.rs
@@ -105,6 +105,10 @@ pub trait WasmValue: Clone + Sized {
         unimplemented!()
     }
     /// Returns a new WasmValue of the given type.
+    ///
+    /// The fields provided by `fields` are not necessarily sorted; the callee
+    /// should perform sorting itself if needed.
+    ///
     /// # Panics
     /// Panics if the type is not implemented (the trait default).
     fn make_record<'a>(
@@ -150,6 +154,10 @@ pub trait WasmValue: Clone + Sized {
         unimplemented!()
     }
     /// Returns a new WasmValue of the given type.
+    ///
+    /// The strings provided by `names` are not necessarily sorted; the callee
+    /// should perform sorting itself if needed.
+    ///
     /// # Panics
     /// Panics if the type is not implemented (the trait default).
     fn make_flags<'a>(

--- a/src/value/mod.rs
+++ b/src/value/mod.rs
@@ -290,7 +290,7 @@ impl WasmValue for Value {
         names: impl IntoIterator<Item = &'a str>,
     ) -> Result<Self, Self::Error> {
         let flag_names = ty.flags_names().collect::<Vec<_>>();
-        let flags = names
+        let mut flags = names
             .into_iter()
             .map(|name| {
                 flag_names
@@ -299,6 +299,9 @@ impl WasmValue for Value {
                     .ok_or_else(|| ValueError::InvalidValue(format!("unknown flag `{name}`")))
             })
             .collect::<Result<Vec<_>, ValueError>>()?;
+        // Flags values don't logically contain an ordering of the flags. Sort
+        // the flags values so that equivalent flags values compare equal.
+        flags.sort();
         let ty = maybe_unwrap!(&ty.0, TypeEnum::Flags).unwrap().clone();
         Ok(Self(ValueEnum::Flags(Flags { ty, flags })))
     }

--- a/src/value/tests.rs
+++ b/src/value/tests.rs
@@ -115,7 +115,7 @@ fn flags_round_trips() {
     let ty = Type::flags(["read", "write", "execute"]).unwrap();
     test_value_round_trip(Value::make_flags(&ty, []).unwrap());
     test_value_round_trip(Value::make_flags(&ty, ["write"]).unwrap());
-    test_value_round_trip(Value::make_flags(&ty, ["execute", "read"]).unwrap());
+    test_value_round_trip(Value::make_flags(&ty, ["read", "execute"]).unwrap());
 }
 
 fn test_value_round_trip(val: Value) {


### PR DESCRIPTION
Fix `Value::make_flags` to sort the flags so that it doens't depend on the incoming order, and simplify the flags parsing to avoid trying to order the flags.

And add tests for flags reordering and errors.