### PR TITLE
Fix the EBNF to allow empty list and flags values.

### DIFF
--- a/wave_ebnf.md
+++ b/wave_ebnf.md
@@ -48,12 +48,14 @@ variant-case-payload ::= '(' value-ws ')'
 
 tuple ::= '(' values-seq ','? ')'
 
-list ::= '[' values-seq ','? ']'
+list ::= '[' ws ']'
+       | '[' values-seq ','? ']'
 
 values-seq ::= value-ws
              | values ',' values-ws
 
-flags ::= '{' flags-seq ','? '}'
+flags ::= '{' ws '}'
+        | '{' flags-seq ','? '}'
 flags-seq ::= ws label ws
             | flags-seq ',' label
 


### PR DESCRIPTION
Lists and flag sets are permitted to be empty. This (narrowly) avoids ambiguity with records on "{}", because records are not permitted to be empty.