### PR TITLE
Multiline strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,50 @@ Chars are encoded as `'<char>'`, where `<char>` is one of:
   - `\r` → U+D (CR)
   - `\u{···}` → U+··· (where `···` is a hexadecimal Unicode Scalar Value)
 
-Escaping `\` and `'` is mandatory for chars.
+Escaping newline (`\n`), `\`, and `'` is mandatory for chars.
 
 ### Strings
 
-Strings are encoded as a double-quote-delimited sequence of `<char>`s (as for [Chars](#chars)). Escaping `\` and `"` is mandatory for strings.
+Strings are encoded as a double-quote-delimited sequence of `<char>`s (as for [Chars](#chars)).
+
+Escaping newline (`\n`), `\`, and `"` is mandatory for strings.
+
+### Multiline Strings
+
+A multiline string begins with `"""` followed immediately by a line break (`\n` or `\r\n`) and ends with a line break, zero or more spaces, and `"""`. The number of spaces immediately preceding the ending `"""` determines the indent level of the entire multiline string. Every other line break in the string must be followed by at least this many spaces which are then omitted ("dedented") from the decoded string.
+
+Each line break in the encoded string except for the first and last is decoded as a newline character (`\n`).
+
+Escaping `\` is mandatory for multiline strings. Escaping carriage return (`\r`) is mandatory immediately before a literal newline character (`\n`) if it is to be retained. Escaping `"` is mandatory where necessary to break up any sequence of `"""` within a string, even if the first `"` is escaped (i.e. `\"""` is prohibited).
+
+```python
+"""
+A single line
+"""
+```
+→ `"A single line"`
+
+```python
+"""
+    Indentation determined
+      by ending delimiter
+  """
+```
+→
+```clike
+"  Indentation determined\n    by ending delimiter"
+```
+
+```python
+"""
+  Must escape carriage return at end of line: \r
+  Must break up double quote triplets: ""\""
+  """
+```
+→
+```clike
+"Must escape carriage return at end of line: \r\nMust break up double quote triplets: \"\"\"\""
+```
 
 ### Tuples
 

--- a/src/lex.rs
+++ b/src/lex.rs
@@ -54,12 +54,16 @@ pub enum Token {
     LabelOrKeyword,
 
     /// A char literal
-    #[regex(r#"'([^\\']{1,4}|(?&char_escape))'"#, validate_char)]
+    #[regex(r#"'([^\\'\n]{1,4}|(?&char_escape))'"#, validate_char)]
     Char,
 
     /// A string literal
-    #[regex(r#""([^\\"]|(?&char_escape))*""#)]
+    #[regex(r#""([^\\"\n]|(?&char_escape))*""#)]
     String,
+
+    /// A multi-line string literal
+    #[token(r#"""""#, lex_multiline_string)]
+    MultilineString,
 }
 
 impl Display for Token {
@@ -74,6 +78,15 @@ fn validate_char(lex: &mut Lexer) -> Result<(), Option<Span>> {
         Ok(())
     } else {
         Err(Some(lex.span()))
+    }
+}
+
+fn lex_multiline_string(lex: &mut Lexer) -> bool {
+    if let Some(end) = lex.remainder().find(r#"""""#) {
+        lex.bump(end + 3);
+        true
+    } else {
+        false
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -8,11 +8,12 @@
 pub mod ast;
 pub mod lex;
 pub mod parser;
+mod strings;
 pub mod untyped;
 pub mod value;
+pub mod wasm;
 pub mod writer;
 
-pub mod wasm;
 #[cfg(feature = "wasmtime")]
 /// Implementations for [`wasmtime`] types.
 pub mod wasmtime;

--- a/src/parser.rs
+++ b/src/parser.rs
@@ -71,6 +71,7 @@ impl<'source> Parser<'source> {
             Token::Number => self.leaf_node(NodeType::Number),
             Token::Char => self.leaf_node(NodeType::Char),
             Token::String => self.leaf_node(NodeType::String),
+            Token::MultilineString => self.leaf_node(NodeType::MultilineString),
             Token::ParenOpen => self.parse_tuple()?,
             Token::BracketOpen => self.parse_list()?,
             Token::BraceOpen => self.parse_record_or_flags()?,
@@ -84,7 +85,11 @@ impl<'source> Parser<'source> {
                 Some(Keyword::Inf | Keyword::Nan) => self.leaf_node(NodeType::Number),
                 None => self.parse_label_maybe_payload()?,
             },
-            _ => return Err(self.unexpected_token()),
+            Token::BraceClose
+            | Token::ParenClose
+            | Token::BracketClose
+            | Token::Colon
+            | Token::Comma => return Err(self.unexpected_token()),
         })
     }
 
@@ -406,6 +411,7 @@ pub enum ParserErrorKind {
     EmptyTuple,
     MultipleChars,
     InvalidEscape,
+    InvalidMultilineString,
     InvalidParams,
     InvalidToken,
     InvalidType,
@@ -424,6 +430,7 @@ impl Display for ParserErrorKind {
             ParserErrorKind::EmptyTuple => "empty tuple",
             ParserErrorKind::MultipleChars => "multiple characters in char value",
             ParserErrorKind::InvalidEscape => "invalid character escape",
+            ParserErrorKind::InvalidMultilineString => "invalid multiline string",
             ParserErrorKind::InvalidParams => "invalid params",
             ParserErrorKind::InvalidToken => "invalid token",
             ParserErrorKind::InvalidType => "invalid value type",

--- a/src/strings.rs
+++ b/src/strings.rs
@@ -1,0 +1,202 @@
+use std::{borrow::Cow, str::Split};
+
+use crate::parser::{ParserError, ParserErrorKind};
+
+/// An iterator over parsed string "parts".
+pub enum StringPartsIter<'a> {
+    Normal(StringParts<'a>),
+    Multiline(MultilineStringParts<'a>),
+}
+
+impl<'a> StringPartsIter<'a> {
+    /// Returns an iterator over string parts for the given substring containing
+    /// only the _inner_ contents (between quotes) of a single-line string.
+    /// The given pos is the source position of this substring for error reporting.
+    pub fn new(src: &'a str, pos: usize) -> Self {
+        Self::Normal(StringParts { src, pos })
+    }
+
+    /// Returns an iterator over string parts for the given substring containing
+    /// only the _inner_ contents (between quotes) of a multiline string.
+    /// The given pos is the source position of this substring for error reporting.
+    pub fn new_multiline(src: &'a str, pos: usize) -> Result<Self, ParserError> {
+        Ok(Self::Multiline(MultilineStringParts::new(src, pos)?))
+    }
+}
+
+impl<'a> Iterator for StringPartsIter<'a> {
+    type Item = Result<Cow<'a, str>, ParserError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            StringPartsIter::Normal(parts) => parts.next(),
+            StringPartsIter::Multiline(parts) => parts.next(),
+        }
+    }
+}
+
+pub struct StringParts<'a> {
+    src: &'a str,
+    pos: usize,
+}
+
+impl<'a> StringParts<'a> {
+    fn next_part(&mut self) -> Result<Cow<'a, str>, ParserError> {
+        let (part, consumed) = match self.src.find('\\') {
+            Some(0) => {
+                let (esc_char, esc_len) = unescape(self.src).ok_or_else(|| {
+                    ParserError::new(ParserErrorKind::InvalidEscape, self.pos..self.pos + 1)
+                })?;
+                (Cow::Owned(esc_char.to_string()), esc_len)
+            }
+            Some(next_esc) => {
+                let esc_prefix = &self.src[..next_esc];
+                (Cow::Borrowed(esc_prefix), esc_prefix.len())
+            }
+            None => (Cow::Borrowed(self.src), self.src.len()),
+        };
+        self.src = &self.src[consumed..];
+        self.pos += consumed;
+        Ok(part)
+    }
+}
+
+impl<'a> Iterator for StringParts<'a> {
+    type Item = Result<Cow<'a, str>, ParserError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.src.is_empty() {
+            return None;
+        }
+        Some(self.next_part())
+    }
+}
+
+/// An iterator over parsed string "parts", each of which is either a literal
+/// substring of the source or a decoded escape sequence.
+pub struct MultilineStringParts<'a> {
+    curr: StringParts<'a>,
+    lines: Split<'a, char>,
+    next_pos: usize,
+    indent: &'a str,
+}
+
+impl<'a> MultilineStringParts<'a> {
+    fn new(src: &'a str, pos: usize) -> Result<Self, ParserError> {
+        let end = pos + src.len();
+
+        // Strip leading carriage return as part of first newline
+        let (src, next_pos) = match src.strip_prefix('\r') {
+            Some(src) => (src, pos + 2),
+            None => (src, pos + 1),
+        };
+
+        let mut lines = src.split('\n');
+
+        // Remove mandatory final line, using trailing spaces as indent
+        let indent = lines.next_back().unwrap();
+        if indent.contains(|ch| ch != ' ') {
+            return Err(ParserError::with_detail(
+                ParserErrorKind::InvalidMultilineString,
+                end - 3..end,
+                r#"closing """ must be on a line preceded only by spaces"#,
+            ));
+        }
+
+        // Validate mandatory initial empty line
+        if lines.next() != Some("") {
+            return Err(ParserError::with_detail(
+                ParserErrorKind::InvalidMultilineString,
+                pos..pos + 1,
+                r#"opening """ must be followed immediately by newline"#,
+            ));
+        }
+
+        let mut parts = Self {
+            curr: StringParts { src: "", pos: 0 },
+            lines,
+            next_pos,
+            indent,
+        };
+
+        // Skip first newline
+        if let Some(nl) = parts.next().transpose()? {
+            debug_assert_eq!(nl, "\n");
+        }
+
+        Ok(parts)
+    }
+}
+
+impl<'a> Iterator for MultilineStringParts<'a> {
+    type Item = Result<Cow<'a, str>, ParserError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.curr.src.is_empty() {
+            let next = self.lines.next()?;
+
+            // Update next line position
+            let pos = self.next_pos;
+            self.next_pos += next.len() + 1;
+
+            // Strip indent
+            let Some(src) = next.strip_prefix(self.indent) else {
+                return Some(Err(ParserError::with_detail(
+                    ParserErrorKind::InvalidMultilineString,
+                    pos..pos + 1,
+                    r#"lines must be indented at least as much as closing """"#,
+                )));
+            };
+            let pos = pos + self.indent.len();
+
+            // Strip trailing carriage return for `\r\n` newlines
+            let src = src.strip_suffix('\r').unwrap_or(src);
+
+            self.curr = StringParts { src, pos };
+
+            Some(Ok("\n".into()))
+        } else {
+            Some(self.curr.next_part())
+        }
+    }
+}
+
+// Given a substring starting with an escape sequence, returns the decoded char
+// and length of the sequence, or None if the sequence is invalid.
+pub fn unescape(src: &str) -> Option<(char, usize)> {
+    let mut chars = src.chars();
+    if chars.next() != Some('\\') {
+        return None;
+    }
+    Some(match chars.next()? {
+        '\\' => ('\\', 2),
+        '\'' => ('\'', 2),
+        '"' => ('"', 2),
+        't' => ('\t', 2),
+        'n' => ('\n', 2),
+        'r' => ('\r', 2),
+        'u' => {
+            if chars.next()? != '{' {
+                return None;
+            }
+            let mut val = 0;
+            let mut digits = 0;
+            loop {
+                let ch = chars.next()?;
+                if ch == '}' {
+                    if digits == 0 {
+                        return None;
+                    }
+                    break;
+                }
+                val = (val << 4) | ch.to_digit(16)?;
+                digits += 1;
+                if digits > 6 {
+                    return None;
+                }
+            }
+            (char::from_u32(val)?, digits + 4)
+        }
+        _ => return None,
+    })
+}

--- a/src/untyped.rs
+++ b/src/untyped.rs
@@ -131,7 +131,9 @@ impl std::fmt::Display for UntypedFuncCall<'_> {
 fn fmt_node(f: &mut impl std::fmt::Write, node: &Node, src: &str) -> std::fmt::Result {
     use crate::ast::NodeType::*;
     match node.ty() {
-        BoolTrue | BoolFalse | Number | Char | String | Label => f.write_str(node.slice(src)),
+        BoolTrue | BoolFalse | Number | Char | String | MultilineString | Label => {
+            f.write_str(node.slice(src))
+        }
         Tuple => fmt_sequence(f, '(', ')', node.as_tuple()?, src),
         List => fmt_sequence(f, '[', ']', node.as_list()?, src),
         Record => {

--- a/tests/ui.rs
+++ b/tests/ui.rs
@@ -58,7 +58,7 @@ fn test(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
             Ok((func_name, func_type, values)) => {
                 assert!(
                     !filename.starts_with("reject-"),
-                    "accepted input in in {filename}"
+                    "accepted input {input:?} in {filename}"
                 );
                 write!(out, "{func_name}(")?;
                 let mut first = true;
@@ -75,7 +75,7 @@ fn test(path: &Path) -> Result<String, Box<dyn std::error::Error>> {
             Err(err) => {
                 assert!(
                     !filename.starts_with("accept-"),
-                    "rejected input in in {filename}"
+                    "rejected input {input:?} in {filename}: {err:#}"
                 );
                 writeln!(out, "{err}")?;
             }

--- a/tests/ui/accept-strings.out
+++ b/tests/ui/accept-strings.out
@@ -3,3 +3,11 @@ string(val: "WAVE🌊")
 string(val: "\\\'\"\t\n\r")
 string(val: "\'\'\'")
 string(val: "☃☃☃")
+// Multiline: empty
+string(val: "")
+// Multiline: escapes
+string(val: "Break up double quote sequences: \"\"\"\"\nOther escapes work: \\\'\"\t\n\r☃")
+// Multiline: indent behavior
+string(val: "  Trailing indent\ndetermines dedent\n    behavior.")
+// Multiline: empty lines
+string(val: "\nEmpty leading and trailing lines are retained\n")

--- a/tests/ui/accept-strings.waves
+++ b/tests/ui/accept-strings.waves
@@ -3,3 +3,23 @@ string("WAVE🌊");
 string("\\\'\"\t\n\r");
 string("'\'\u{27}");
 string("☃\u{2603}\u{002603}");
+// Multiline: empty
+string("""
+""");
+// Multiline: escapes
+string("""
+Break up double quote sequences: ""\""
+Other escapes work: \\\'\"\t\n\r\u{2603}
+""");
+// Multiline: indent behavior
+string("""
+    Trailing indent
+  determines dedent
+      behavior.
+  """);
+// Multiline: empty lines
+string("""
+
+Empty leading and trailing lines are retained
+
+""")

--- a/tests/ui/reject-chars.out
+++ b/tests/ui/reject-chars.out
@@ -2,6 +2,7 @@
 invalid token at 5..6
 invalid token at 5..9
 invalid token at 5..9
+invalid token at 5..6
 // Invalid escapes
 invalid token at 5..6
 invalid token at 5..6
@@ -20,3 +21,7 @@ invalid character escape at 5..15
 invalid token at 5..6
 invalid token at 6..7
 invalid token at 5..7
+// Missing mandatory escapes
+invalid token at 5..6
+invalid token at 5..6
+invalid token at 5..6

--- a/tests/ui/reject-chars.waves
+++ b/tests/ui/reject-chars.waves
@@ -2,6 +2,7 @@
 char('');
 char('ab');
 char('☃☃');
+char('\n\n');
 // Invalid escapes
 char('\z');
 char('\x1f');
@@ -20,3 +21,8 @@ char('\u{DFFF}');
 char(');
 char(x');
 char('x);
+// Missing mandatory escapes
+char('\');
+char(''');
+char('
+');

--- a/tests/ui/reject-strings.out
+++ b/tests/ui/reject-strings.out
@@ -1,13 +1,32 @@
 // Reject surrogates.
-invalid character escape at 7..17
-invalid character escape at 7..17
-invalid character escape at 7..17
-invalid character escape at 7..17
-invalid character escape at 7..26
+invalid character escape at 8..9
+invalid character escape at 8..9
+invalid character escape at 8..9
+invalid character escape at 8..9
+invalid character escape at 8..9
 // Reject invalid values.
-invalid character escape at 7..19
-invalid token at 7..16
-invalid token at 7..16
+invalid character escape at 8..9
+invalid character escape at 8..9
+invalid character escape at 8..9
 // Reject invalid syntax.
 invalid token at 7..8
 invalid token at 7..8
+// Missing mandatory escapes
+invalid token at 7..10
+invalid token at 7..11
+invalid token at 7..8
+// Multiline missing mandatory line breaks
+invalid multiline string: opening """ must be followed immediately by newline at 10..11
+invalid multiline string: opening """ must be followed immediately by newline at 10..11
+// Multiline invalid delimiters
+invalid multiline string: opening """ must be followed immediately by newline at 10..11
+invalid token at 7..10
+invalid token at 14..16
+invalid multiline string: opening """ must be followed immediately by newline at 10..11
+invalid multiline string: closing """ must be on a line preceded only by spaces at 13..16
+// Multiline double quote triplet in content
+invalid token at 19..22
+unexpected token: LabelOrKeyword at 25..30
+// Multiline invalid escapes
+invalid character escape at 30..31
+invalid character escape at 27..28

--- a/tests/ui/reject-strings.waves
+++ b/tests/ui/reject-strings.waves
@@ -11,3 +11,36 @@ string("\u{80000000}");
 // Reject invalid syntax.
 string("\u{-1}");
 string("\u{+1}");
+// Missing mandatory escapes
+string(""");
+string("\");
+string("
+");
+// Multiline missing mandatory line breaks
+string("""""");
+string(""" """);
+// Multiline invalid delimiters
+string(""""
+""");
+string("""
+"");
+string("""
+"""");
+string("""extra
+""");
+string("""
+extra""");
+// Multiline double quote triplet in content
+string("""
+  """
+  """);
+string("""
+  Between """ words
+  """);
+// Multiline invalid escapes
+string("""
+Invalid surrogate: \u{d800}
+""");
+string("""
+Invalid escape: \j
+""");

--- a/tests/wasmtime.rs
+++ b/tests/wasmtime.rs
@@ -57,7 +57,7 @@ fn test_round_trip_variations() {
         ("floats", "(1e+10, -5.5e-5)", "(10000000000, -0.000055)"),
         ("floats", "(0.00e100, 1.0e0)", "(0, 1)"),
         ("options", "(1, some(-1))", "(some(1), some(some(-1)))"),
-        ("list-strings", "[\"a\nb\rc\td\",]", r#"["a\nb\rc\td"]"#),
+        ("list-strings", "[\"b\rc\td\",]", r#"["b\rc\td"]"#),
         ("result-ok-only", "1", "ok(1)"),
         ("record", "{required: 1 ,optional: none ,}", "{required: 1}"),
         ("flags", "{read,}", "{read}"),

--- a/wave_ebnf.md
+++ b/wave_ebnf.md
@@ -39,9 +39,15 @@ char-char ::= common-char | '"'
 string ::= '"' string-char* '"'
 string-char ::= common-char | [']
 
-common-char ::= <any Unicode Scalar Value except ['"\]>
+multiline-string ::= '"""' line-break multiline-string-line* [ ]* '"""'
+multiline-string-line ::= [ ]* multiline-string-char* line-break
+multiline-string-char ::= common-char | ['"]
+
+line-break ::= '\r\n' | '\n'
+
+common-char ::= <any Unicode Scalar Value except ['"\n\\]>
               | '\' escape
-escape ::= ['"tnr\] | escape-unicode
+escape ::= ['"tnr\\] | escape-unicode
 escape-unicode ::= 'u{' [0-9a-fA-F]+ '}'
 
 variant-case ::= label ws variant-case-payload?
@@ -75,3 +81,4 @@ word ::= [a-z][a-z0-9]*
 
 * "`Unicode scalar value`" is defined by Unicode
 * `escape-unicode` must identify a valid Unicode scalar value.
+* `multiline-string-line` must not contain `"""`


### PR DESCRIPTION
This adds support for multiline string literals, delimited by double quote triplets (""").

This also disallows literal newlines in char and regular string literals. (ref #31)

Closes #29 
